### PR TITLE
Return string rather than print

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -43,7 +43,7 @@ sub main {
     } elsif (/^read$/) {
         print do_read();
     } elsif (/^write$/) {
-        do_write();
+        print do_write();
     } elsif (/^edit$/) {
         do_edit();
     } elsif (/^index$/) {
@@ -94,15 +94,18 @@ sub do_index {
 }
 
 sub do_write {
+
+    my $html = "";
     if ($q->Vars->{mymsg}) {
         $database{$q->param("mypage")} = $q->Vars->{mymsg};
-        print render_header($q->param("mypage"), 1);
-        print render_content();
+        $html .= render_header($q->param("mypage"), 1);
+        $html .= render_content();
     } else {
         delete $database{$q->param("mypage")};
-        print render_header($q->param("mypage") . $msgdeleted, 0);
+        $html .= render_header($q->param("mypage") . $msgdeleted, 0);
     }
-    print render_footer();
+
+    $html .= render_footer();
 }
 
 sub render_error {

--- a/index.cgi
+++ b/index.cgi
@@ -47,7 +47,7 @@ sub main {
     } elsif (/^edit$/) {
         do_edit();
     } elsif (/^index$/) {
-        do_index();
+        print do_index();
     } else {
         $q->Vars->{mypage} = $frontpage;
         do_read();
@@ -80,13 +80,15 @@ EOD
 }
 
 sub do_index {
-    print render_header($indexpage, 0);
-    print qq|<ul>\n|;
+    my $html = "";
+    $html .= render_header($indexpage, 0);
+    $html .= qq|<ul>\n|;
     foreach (sort keys %database) {
-        print qq|<li><a href="?$_"><tt>$_</tt></a></li>\n|
+        $html .= qq|<li><a href="?$_"><tt>$_</tt></a></li>\n|;
     }
-    print qq|</ul>\n|;
-    print render_footer();
+    $html .= qq|</ul>\n|;
+    $html .= render_footer();
+    return $html;
 }
 
 sub do_write {

--- a/index.cgi
+++ b/index.cgi
@@ -25,7 +25,10 @@ my $q = CGI->new;
 print main();
 
 sub main {
-    sanitize_form();
+    if (! sanitize_form()) {
+        print render_error("(invalid mypage)");
+        exit(0);
+    }
 
     if (defined $q->Vars->{keywords} && $q->Vars->{keywords} =~ /^($WikiName)$/) {
         $q->Vars->{mycmd} = 'read';
@@ -211,7 +214,7 @@ sub make_link {
 
 sub sanitize_form {
     if (defined($q->param("mypage")) and $q->param("mypage") !~ /^$WikiName$/) {
-        print render_error("(invalid mypage)");
-        exit(0);
+        return 0;
     }
+    return 1;
 }

--- a/index.cgi
+++ b/index.cgi
@@ -39,9 +39,9 @@ sub main {
     $_ = $q->Vars->{mycmd};
     if (! $_) {
         $q->Vars->{mypage} = $frontpage;
-        do_read();
+        print do_read();
     } elsif (/^read$/) {
-        do_read();
+        print do_read();
     } elsif (/^write$/) {
         do_write();
     } elsif (/^edit$/) {
@@ -50,15 +50,17 @@ sub main {
         print do_index();
     } else {
         $q->Vars->{mypage} = $frontpage;
-        do_read();
+        print do_read();
     }
     dbmclose(%database);
 }
 
 sub do_read {
-    print render_header($q->param("mypage"), 1);
-    print render_content();
-    print render_footer();
+    my $html = "";
+    $html .= render_header($q->param("mypage"), 1);
+    $html .= render_content();
+    $html .= render_footer();
+    return $html;
 }
 
 sub do_edit {
@@ -184,7 +186,7 @@ sub render_content {
     !
         make_link($1)
     !gex;
-    return "<pre>", $_, "</pre>";
+    return "<pre>". $_. "</pre>";
 }
 
 sub make_link {

--- a/index.cgi
+++ b/index.cgi
@@ -121,7 +121,14 @@ sub print_error {
 
 sub print_header {
     my ($title, $canedit) = @_;
-    my $mypage = $q->param("mypage");
+    my $params = {
+        title => $title,
+        frontpage => $frontpage,
+        mypage => $q->param("mypage") || "",
+        naviedit => $naviedit,
+        naviindex => $naviindex,
+    };
+
     print <<"EOD";
 Content-type: text/html; charset=utf-8
 
@@ -129,19 +136,19 @@ Content-type: text/html; charset=utf-8
 <html>
     <head>
     <meta charset="utf-8">
-    <title>$title</title>
+    <title>$params->{title}</title>
     $style
     </head>
     <body bgcolor="$bgcolor">
         <table width="100%" border="0">
             <tr valign="top">
                 <td>
-                    <h1>$title</h1>
+                    <h1>$params->{title}</h1>
                 </td>
                 <td align="right">
-                    <a href="?$frontpage">$frontpage</a> | 
-                    @{[$canedit ? qq(<a href="?mycmd=edit&mypage=$mypage">$naviedit</a> | ) : '' ]}
-                    <a href="?mycmd=index">$naviindex</a> | 
+                    <a href="?$params->{frontpage}">$params->{frontpage}</a> | 
+                    @{[$canedit ? qq(<a href="?mycmd=edit&mypage=$params->{mypage}">$params->{naviedit}</a> | ) : '' ]}
+                    <a href="?mycmd=index">$params->{naviindex}</a> | 
                     <a href="http://www.hyuki.com/yukiwiki/mini/">YukiWikiMini</a>
                 </td>
             </tr>

--- a/index.cgi
+++ b/index.cgi
@@ -11,7 +11,6 @@ my $indexpage = 'Index';
 my $errorpage = 'Error';
 my $WikiName = '([A-Z][a-z]+([A-Z][a-z]+)+)';
 my $editchar = '?';
-my $bgcolor = 'white';
 my $naviwrite = 'Write';
 my $naviedit = 'Edit';
 my $naviindex = 'Index';
@@ -127,6 +126,7 @@ sub print_header {
         mypage => $q->param("mypage") || "",
         naviedit => $naviedit,
         naviindex => $naviindex,
+        canedit => $canedit,
     };
 
     print <<"EOD";
@@ -139,7 +139,7 @@ Content-type: text/html; charset=utf-8
     <title>$params->{title}</title>
     $style
     </head>
-    <body bgcolor="$bgcolor">
+    <body bgcolor="white">
         <table width="100%" border="0">
             <tr valign="top">
                 <td>
@@ -147,7 +147,7 @@ Content-type: text/html; charset=utf-8
                 </td>
                 <td align="right">
                     <a href="?$params->{frontpage}">$params->{frontpage}</a> | 
-                    @{[$canedit ? qq(<a href="?mycmd=edit&mypage=$params->{mypage}">$params->{naviedit}</a> | ) : '' ]}
+                    @{[$params->{canedit} ? qq(<a href="?mycmd=edit&mypage=$params->{mypage}">$params->{naviedit}</a> | ) : '' ]}
                     <a href="?mycmd=index">$params->{naviindex}</a> | 
                     <a href="http://www.hyuki.com/yukiwiki/mini/">YukiWikiMini</a>
                 </td>

--- a/index.cgi
+++ b/index.cgi
@@ -55,13 +55,13 @@ sub main {
 }
 
 sub do_read {
-    print_header($q->param("mypage"), 1);
+    print render_header($q->param("mypage"), 1);
     print_content();
     print_footer();
 }
 
 sub do_edit {
-    print_header($q->param("mypage"), 0);
+    print render_header($q->param("mypage"), 0);
     my $mymsg = escape($database{$q->param("mypage")});
     $mymsg = "" unless defined $mymsg;
     my $mypage = $q->param("mypage");
@@ -79,7 +79,7 @@ EOD
 }
 
 sub do_index {
-    print_header($indexpage, 0);
+    print render_header($indexpage, 0);
     print qq|<ul>\n|;
     foreach (sort keys %database) {
         print qq|<li><a href="?$_"><tt>$_</tt></a></li>\n|
@@ -91,24 +91,24 @@ sub do_index {
 sub do_write {
     if ($q->Vars->{mymsg}) {
         $database{$q->param("mypage")} = $q->Vars->{mymsg};
-        print_header($q->param("mypage"), 1);
+        print render_header($q->param("mypage"), 1);
         print_content();
     } else {
         delete $database{$q->param("mypage")};
-        print_header($q->param("mypage") . $msgdeleted, 0);
+        print render_header($q->param("mypage") . $msgdeleted, 0);
     }
     print_footer();
 }
 
 sub print_error {
     my $msg = shift;
-    print_header($errorpage, 0);
+    print render_header($errorpage, 0);
     print "<h1>$msg</h1>";
     print_footer();
     exit(0);
 }
 
-sub print_header {
+sub render_header {
     my ($title, $canedit) = @_;
     my $params = {
         title => $title,
@@ -119,7 +119,7 @@ sub print_header {
         canedit => $canedit,
     };
 
-    print <<"EOD";
+    my $html =  <<"EOD";
 Content-type: text/html; charset=utf-8
 
 <!DOCTYPE html>

--- a/index.cgi
+++ b/index.cgi
@@ -26,8 +26,7 @@ print main();
 
 sub main {
     if (! sanitize_form()) {
-        print render_error("(invalid mypage)");
-        exit(0);
+        return render_error("(invalid mypage)");
     }
 
     if (defined $q->Vars->{keywords} && $q->Vars->{keywords} =~ /^($WikiName)$/) {

--- a/index.cgi
+++ b/index.cgi
@@ -17,16 +17,6 @@ my $naviindex = 'Index';
 my $msgdeleted = ' is deleted.';
 my $cols = 80;
 my $rows = 20;
-my $style = <<'EOD';
-<style type="text/css">
-<!--
-body { font-family: "Courier New", monospace; }
-pre { line-height:130%; }
-a { text-decoration: none }
-a:hover { text-decoration: underline }
--->
-</style>
-EOD
 
 my %form;
 my %database;
@@ -137,7 +127,14 @@ Content-type: text/html; charset=utf-8
     <head>
     <meta charset="utf-8">
     <title>$params->{title}</title>
-    $style
+    <style type="text/css">
+    <!--
+    body { font-family: "Courier New", monospace; }
+    pre { line-height:130%; }
+    a { text-decoration: none }
+    a:hover { text-decoration: underline }
+    -->
+    </style>
     </head>
     <body bgcolor="white">
         <table width="100%" border="0">

--- a/index.cgi
+++ b/index.cgi
@@ -33,7 +33,8 @@ sub main {
     }
 
     unless (dbmopen(%database, $dbname, 0666)) {
-        print_error("(dbmopen)");
+        print render_error("(dbmopen)");
+        exit(0);
     }
     $_ = $q->Vars->{mycmd};
     if (! $_) {
@@ -56,8 +57,8 @@ sub main {
 
 sub do_read {
     print render_header($q->param("mypage"), 1);
-    print_content();
-    print_footer();
+    print render_content();
+    print render_footer();
 }
 
 sub do_edit {
@@ -75,7 +76,7 @@ sub do_edit {
         <input type="submit" value="$naviwrite">
     </form>
 EOD
-    print_footer();
+    print render_footer();
 }
 
 sub do_index {
@@ -85,27 +86,28 @@ sub do_index {
         print qq|<li><a href="?$_"><tt>$_</tt></a></li>\n|
     }
     print qq|</ul>\n|;
-    print_footer();
+    print render_footer();
 }
 
 sub do_write {
     if ($q->Vars->{mymsg}) {
         $database{$q->param("mypage")} = $q->Vars->{mymsg};
         print render_header($q->param("mypage"), 1);
-        print_content();
+        print render_content();
     } else {
         delete $database{$q->param("mypage")};
         print render_header($q->param("mypage") . $msgdeleted, 0);
     }
-    print_footer();
+    print render_footer();
 }
 
-sub print_error {
+sub render_error {
     my $msg = shift;
-    print render_header($errorpage, 0);
-    print "<h1>$msg</h1>";
-    print_footer();
-    exit(0);
+    my $html;
+    $html = render_header($errorpage, 0);
+    $html .= "<h1>$msg</h1>";
+    $html .= render_footer();
+    return $html;
 }
 
 sub render_header {
@@ -153,8 +155,8 @@ Content-type: text/html; charset=utf-8
 EOD
 }
 
-sub print_footer {
-    print "</body></html>";
+sub render_footer {
+    return "</body></html>";
 }
 
 sub escape {
@@ -169,7 +171,7 @@ sub escape {
     return $_;
 }
 
-sub print_content {
+sub render_content {
     $_ = escape($database{$q->param("mypage")});
     s!
         (
@@ -180,7 +182,7 @@ sub print_content {
     !
         make_link($1)
     !gex;
-    print "<pre>", $_, "</pre>";
+    return "<pre>", $_, "</pre>";
 }
 
 sub make_link {
@@ -198,6 +200,7 @@ sub make_link {
 
 sub sanitize_form {
     if (defined($q->param("mypage")) and $q->param("mypage") !~ /^$WikiName$/) {
-        print_error("(invalid mypage)");
+        print render_error("(invalid mypage)");
+        exit(0);
     }
 }

--- a/index.cgi
+++ b/index.cgi
@@ -22,7 +22,7 @@ my %form;
 my %database;
 my $q = CGI->new;
 
-main();
+print main();
 
 sub main {
     sanitize_form();
@@ -32,27 +32,29 @@ sub main {
         $q->Vars->{mypage} = $1;
     }
 
+    my $html;
     unless (dbmopen(%database, $dbname, 0666)) {
-        print render_error("(dbmopen)");
-        exit(0);
+        return render_error("(dbmopen)");
     }
+
     $_ = $q->Vars->{mycmd};
     if (! $_) {
         $q->Vars->{mypage} = $frontpage;
-        print do_read();
+        $html = do_read();
     } elsif (/^read$/) {
-        print do_read();
+        $html = do_read();
     } elsif (/^write$/) {
-        print do_write();
+        $html = do_write();
     } elsif (/^edit$/) {
-        print do_edit();
+        $html = do_edit();
     } elsif (/^index$/) {
-        print do_index();
+        $html = do_index();
     } else {
         $q->Vars->{mypage} = $frontpage;
-        print do_read();
+        $html = do_read();
     }
     dbmclose(%database);
+    return $html;
 }
 
 sub do_read {

--- a/index.cgi
+++ b/index.cgi
@@ -45,7 +45,7 @@ sub main {
     } elsif (/^write$/) {
         print do_write();
     } elsif (/^edit$/) {
-        do_edit();
+        print do_edit();
     } elsif (/^index$/) {
         print do_index();
     } else {
@@ -64,12 +64,13 @@ sub do_read {
 }
 
 sub do_edit {
-    print render_header($q->param("mypage"), 0);
+    my $html = "";
+    $html .=  render_header($q->param("mypage"), 0);
     my $mymsg = escape($database{$q->param("mypage")});
     $mymsg = "" unless defined $mymsg;
     my $mypage = $q->param("mypage");
 
-    print <<"EOD";
+    $html .=  <<"EOD";
     <form action="." method="post">
         <input type="hidden" name="mycmd" value="write">
         <input type="hidden" name="mypage" value="$mypage">
@@ -78,7 +79,7 @@ sub do_edit {
         <input type="submit" value="$naviwrite">
     </form>
 EOD
-    print render_footer();
+    $html .=  render_footer();
 }
 
 sub do_index {
@@ -106,6 +107,7 @@ sub do_write {
     }
 
     $html .= render_footer();
+    return $html;
 }
 
 sub render_error {

--- a/index.cgi
+++ b/index.cgi
@@ -8,7 +8,6 @@ our $VERSION = "1.2.0";
 my $dbname = 'ykwkmini';
 my $frontpage = 'FrontPage';
 my $indexpage = 'Index';
-my $errorpage = 'Error';
 my $WikiName = '([A-Z][a-z]+([A-Z][a-z]+)+)';
 my $editchar = '?';
 my $naviwrite = 'Write';
@@ -116,6 +115,8 @@ sub do_write {
 
 sub render_error {
     my $msg = shift;
+    my $errorpage = 'Error';
+
     my $html;
     $html = render_header($errorpage, 0);
     $html .= "<h1>$msg</h1>";


### PR DESCRIPTION
printを何度も呼ぶのは下記の理由から好ましくないので、サブルーチンは文字列をreturnして最後に一回だけprintするようにする。
- unit testしにくい
- psgi化できない
- 文字列を組み立てることと、レスポンスを出力することは別々の仕事である
